### PR TITLE
Fix dead links in markdown docs

### DIFF
--- a/src/pages/docs/getting-started/index.md
+++ b/src/pages/docs/getting-started/index.md
@@ -66,4 +66,4 @@ ez version
 
 ### Uninstall
 
-Need to remove EZ or start fresh? See the [uninstall guide](/docs/getting-started/uninstall).
+Need to remove EZ or start fresh? See the [uninstall guide](/language.ez/docs/getting-started/uninstall).

--- a/src/pages/docs/getting-started/repl.md
+++ b/src/pages/docs/getting-started/repl.md
@@ -213,6 +213,6 @@ ez> int(17.0 / 5.0)
 
 ## Next Steps
 
-- [Variables](/docs/language/variables) — Learn about `temp` and `const`
-- [Functions](/docs/language/functions) — Create reusable code
-- [Types](/docs/language/types) — Understand the type system
+- [Variables](/language.ez/docs/language/variables) — Learn about `temp` and `const`
+- [Functions](/language.ez/docs/language/functions) — Create reusable code
+- [Types](/language.ez/docs/language/types) — Understand the type system

--- a/src/pages/docs/index.md
+++ b/src/pages/docs/index.md
@@ -10,7 +10,7 @@ Welcome to the EZ documentation. EZ is a simple programming language designed to
 
 ## Quick Start
 
-1. [Install EZ](/docs/getting-started) for your platform
+1. [Install EZ](/language.ez/docs/getting-started) for your platform
 2. Create `hello.ez`:
 
 ```ez
@@ -29,14 +29,14 @@ ez run hello.ez
 
 ## What's Next?
 
-### [Getting Started](/docs/getting-started)
+### [Getting Started](/language.ez/docs/getting-started)
 Install EZ and write your first program.
 
-### [Language Reference](/docs/language/variables)
+### [Language Reference](/language.ez/docs/language/variables)
 Learn about variables, functions, and more.
 
-### [Standard Library](/docs/stdlib/std)
+### [Standard Library](/language.ez/docs/stdlib/std)
 Explore the built-in modules.
 
-### [Examples](/examples)
+### [Examples](/language.ez/examples)
 Real-world code examples and recipes.

--- a/src/pages/docs/stdlib/arrays.md
+++ b/src/pages/docs/stdlib/arrays.md
@@ -47,7 +47,7 @@ std.println(arr)   // {1, 2}
 
 **Returns:** The removed element.
 
-**Errors:** [E9001](/errors/E9001) if the array is empty.
+**Errors:** [E9001](/language.ez/errors/E9001) if the array is empty.
 
 ### shift
 
@@ -64,7 +64,7 @@ std.println(arr)    // {2, 3}
 
 **Returns:** The removed element.
 
-**Errors:** [E9002](/errors/E9002) if the array is empty.
+**Errors:** [E9002](/language.ez/errors/E9002) if the array is empty.
 
 ### unshift
 
@@ -94,7 +94,7 @@ std.println(arr)  // {1, 2, 3, 4}
 
 **Returns:** Nothing (mutates array in place).
 
-**Errors:** [E9003](/errors/E9003) if the index is out of bounds.
+**Errors:** [E9003](/language.ez/errors/E9003) if the index is out of bounds.
 
 ### remove_at
 
@@ -110,7 +110,7 @@ std.println(arr)  // {1, 3, 4}
 
 **Returns:** Nothing (mutates array in place).
 
-**Errors:** [E9006](/errors/E9006) if the index is out of bounds.
+**Errors:** [E9006](/language.ez/errors/E9006) if the index is out of bounds.
 
 ## Accessing Elements
 
@@ -128,7 +128,7 @@ std.println(val)  // 20
 
 **Returns:** The element at the index.
 
-**Errors:** [E9004](/errors/E9004) if the index is out of bounds.
+**Errors:** [E9004](/language.ez/errors/E9004) if the index is out of bounds.
 
 ### set
 
@@ -144,7 +144,7 @@ std.println(arr)  // {1, 20, 3}
 
 **Returns:** Nothing (mutates array in place).
 
-**Errors:** [E9005](/errors/E9005) if the index is out of bounds.
+**Errors:** [E9005](/language.ez/errors/E9005) if the index is out of bounds.
 
 ### first / last
 
@@ -220,7 +220,7 @@ std.println(sub)  // {2, 3, 4}
 
 **Returns:** A new array with the slice.
 
-**Errors:** [E9016](/errors/E9016) if indices are not integers.
+**Errors:** [E9016](/language.ez/errors/E9016) if indices are not integers.
 
 ### concat
 
@@ -237,7 +237,7 @@ std.println(c)  // {1, 2, 3, 4}
 
 **Returns:** A new concatenated array.
 
-**Errors:** [E9014](/errors/E9014) if arguments are not arrays.
+**Errors:** [E9014](/language.ez/errors/E9014) if arguments are not arrays.
 
 ### repeat
 
@@ -252,7 +252,7 @@ std.println(arr)  // {0, 0, 0, 0, 0}
 
 **Returns:** A new array.
 
-**Errors:** [E9017](/errors/E9017) if count is not an integer.
+**Errors:** [E9017](/language.ez/errors/E9017) if count is not an integer.
 
 ## Numeric Arrays
 
@@ -269,7 +269,7 @@ std.println(arrays.sum(arr))  // 15
 
 **Returns:** The sum.
 
-**Errors:** [E9010](/errors/E9010) if the array is not numeric.
+**Errors:** [E9010](/language.ez/errors/E9010) if the array is not numeric.
 
 ### product
 
@@ -284,7 +284,7 @@ std.println(arrays.product(arr))  // 120
 
 **Returns:** The product.
 
-**Errors:** [E9011](/errors/E9011) if the array is not numeric.
+**Errors:** [E9011](/language.ez/errors/E9011) if the array is not numeric.
 
 ### min / max
 
@@ -300,7 +300,7 @@ std.println(arrays.max(arr))  // 9
 
 **Returns:** The min or max value.
 
-**Errors:** [E9007](/errors/E9007) min if array is empty, [E9008](/errors/E9008) max if array is empty.
+**Errors:** [E9007](/language.ez/errors/E9007) min if array is empty, [E9008](/language.ez/errors/E9008) max if array is empty.
 
 ### avg
 
@@ -315,7 +315,7 @@ std.println(arrays.avg(arr))  // 6.0
 
 **Returns:** `float` - The average.
 
-**Errors:** [E9009](/errors/E9009) if array is empty, [E9012](/errors/E9012) if not numeric.
+**Errors:** [E9009](/language.ez/errors/E9009) if array is empty, [E9012](/language.ez/errors/E9012) if not numeric.
 
 ## Utilities
 
@@ -336,7 +336,7 @@ std.println(odds)  // {1, 3, 5, 7, 9}
 
 **Returns:** A new array of integers.
 
-**Errors:** [E9013](/errors/E9013) if step is zero.
+**Errors:** [E9013](/language.ez/errors/E9013) if step is zero.
 
 ### join
 
@@ -354,7 +354,7 @@ std.println(arrays.join(nums, ", "))  // "1, 2, 3"
 
 **Returns:** `string` - The joined string.
 
-**Errors:** [E9018](/errors/E9018) if separator is not a string.
+**Errors:** [E9018](/language.ez/errors/E9018) if separator is not a string.
 
 ### zip
 
@@ -371,7 +371,7 @@ temp pairs = arrays.zip(names, ages)
 
 **Returns:** An array of pairs.
 
-**Errors:** [E9015](/errors/E9015) if arguments are not arrays.
+**Errors:** [E9015](/language.ez/errors/E9015) if arguments are not arrays.
 
 ## Example Program
 

--- a/src/pages/docs/stdlib/index.md
+++ b/src/pages/docs/stdlib/index.md
@@ -123,7 +123,7 @@ do main() {
 
 The prefix makes it clear where each function comes from, which helps when learning. Once you're comfortable, experiment with `using` or aliases if you prefer shorter code.
 
-See the [Modules](/docs/language/modules) page for more details on the module system.
+See the [Modules](/language.ez/docs/language/modules) page for more details on the module system.
 
 ## Available Modules
 
@@ -131,12 +131,12 @@ EZ includes six built-in modules:
 
 | Module | What it's for |
 |--------|---------------|
-| [@std](/docs/stdlib/std) | Basic input/output — printing text, getting user input |
-| [@math](/docs/stdlib/math) | Math operations — square roots, powers, random numbers |
-| [@arrays](/docs/stdlib/arrays) | Working with lists — sorting, filtering, finding items |
-| [@strings](/docs/stdlib/strings) | Working with text — uppercase, splitting, trimming |
-| [@maps](/docs/stdlib/maps) | Key-value storage — like a dictionary or phonebook |
-| [@time](/docs/stdlib/time) | Dates and time — current time, formatting, delays |
+| [@std](/language.ez/docs/stdlib/std) | Basic input/output — printing text, getting user input |
+| [@math](/language.ez/docs/stdlib/math) | Math operations — square roots, powers, random numbers |
+| [@arrays](/language.ez/docs/stdlib/arrays) | Working with lists — sorting, filtering, finding items |
+| [@strings](/language.ez/docs/stdlib/strings) | Working with text — uppercase, splitting, trimming |
+| [@maps](/language.ez/docs/stdlib/maps) | Key-value storage — like a dictionary or phonebook |
+| [@time](/language.ez/docs/stdlib/time) | Dates and time — current time, formatting, delays |
 
 ## Quick Example
 
@@ -176,9 +176,9 @@ do main() {
 
 Pick a module and explore what it can do:
 
-- [@std](/docs/stdlib/std) — Start here, it's the most common
-- [@math](/docs/stdlib/math) — For calculations and random numbers
-- [@arrays](/docs/stdlib/arrays) — For working with lists of things
-- [@strings](/docs/stdlib/strings) — For manipulating text
-- [@maps](/docs/stdlib/maps) — For key-value data
-- [@time](/docs/stdlib/time) — For dates, times, and delays
+- [@std](/language.ez/docs/stdlib/std) — Start here, it's the most common
+- [@math](/language.ez/docs/stdlib/math) — For calculations and random numbers
+- [@arrays](/language.ez/docs/stdlib/arrays) — For working with lists of things
+- [@strings](/language.ez/docs/stdlib/strings) — For manipulating text
+- [@maps](/language.ez/docs/stdlib/maps) — For key-value data
+- [@time](/language.ez/docs/stdlib/time) — For dates, times, and delays

--- a/src/pages/docs/stdlib/maps.md
+++ b/src/pages/docs/stdlib/maps.md
@@ -47,7 +47,7 @@ std.println(age)  // 25
 
 **Returns:** The value associated with the key.
 
-**Errors:** [E12006](/errors/E12006) if the key is not found.
+**Errors:** [E12006](/language.ez/errors/E12006) if the key is not found.
 
 ### set
 
@@ -63,7 +63,7 @@ maps.set(ages, "Alice", 26)  // update existing
 
 **Returns:** Nothing (mutates map in place).
 
-**Errors:** [E12003](/errors/E12003) if the map is immutable (const).
+**Errors:** [E12003](/language.ez/errors/E12003) if the map is immutable (const).
 
 ### has
 
@@ -109,7 +109,7 @@ std.println(names)  // {"Alice", "Bob"}
 
 **Returns:** `[any]` - Array of keys.
 
-**Errors:** [E12001](/errors/E12001) if the argument is not a map.
+**Errors:** [E12001](/language.ez/errors/E12001) if the argument is not a map.
 
 ### values
 
@@ -234,7 +234,7 @@ temp arr [int] = {1, 2, 3}
 // maps.set(myMap, arr, "value")  // Error: array not hashable
 ```
 
-**Error:** [E12002](/errors/E12002) if you try to use a non-hashable key.
+**Error:** [E12002](/language.ez/errors/E12002) if you try to use a non-hashable key.
 
 ## Example Program
 

--- a/src/pages/docs/stdlib/math.md
+++ b/src/pages/docs/stdlib/math.md
@@ -66,7 +66,7 @@ math.avg(10, 20)   // 15.0
 
 **Returns:** `float` - The arithmetic mean.
 
-**Errors:** [E8012](/errors/E8012) if called with no arguments.
+**Errors:** [E8012](/language.ez/errors/E8012) if called with no arguments.
 
 ### floor / ceil / round
 
@@ -112,7 +112,7 @@ math.sqrt(2)    // 1.4142135623730951
 
 **Returns:** `float` - The square root.
 
-**Errors:** [E8001](/errors/E8001) if the argument is negative.
+**Errors:** [E8001](/language.ez/errors/E8001) if the argument is negative.
 
 ## Logarithms
 
@@ -129,7 +129,7 @@ math.log(10)       // 2.302585...
 
 **Returns:** `float` - The natural logarithm.
 
-**Errors:** [E8002](/errors/E8002) if the argument is not positive.
+**Errors:** [E8002](/language.ez/errors/E8002) if the argument is not positive.
 
 ### log2
 
@@ -144,7 +144,7 @@ math.log2(16)  // 4.0
 
 **Returns:** `float` - The base-2 logarithm.
 
-**Errors:** [E8003](/errors/E8003) if the argument is not positive.
+**Errors:** [E8003](/language.ez/errors/E8003) if the argument is not positive.
 
 ### log10
 
@@ -159,7 +159,7 @@ math.log10(1000)  // 3.0
 
 **Returns:** `float` - The base-10 logarithm.
 
-**Errors:** [E8004](/errors/E8004) if the argument is not positive.
+**Errors:** [E8004](/language.ez/errors/E8004) if the argument is not positive.
 
 ## Trigonometry
 
@@ -191,7 +191,7 @@ math.atan(1)   // 0.7853981... (PI/4)
 
 **Returns:** `float` - Angle in radians.
 
-**Errors:** [E8005](/errors/E8005) asin if value outside [-1, 1], [E8006](/errors/E8006) acos if value outside [-1, 1].
+**Errors:** [E8005](/language.ez/errors/E8005) asin if value outside [-1, 1], [E8006](/language.ez/errors/E8006) acos if value outside [-1, 1].
 
 ## Other Functions
 
@@ -209,7 +209,7 @@ math.factorial(10)  // 3628800
 
 **Returns:** `int` - n!
 
-**Errors:** [E8007](/errors/E8007) for negative numbers, [E8008](/errors/E8008) for values > 20.
+**Errors:** [E8007](/language.ez/errors/E8007) for negative numbers, [E8008](/language.ez/errors/E8008) for values > 20.
 
 ## Random Numbers
 
@@ -229,7 +229,7 @@ math.random(10, 20)   // 10-19
 
 **Returns:** `int` - A random integer.
 
-**Errors:** [E8009](/errors/E8009) if max is not positive, [E8010](/errors/E8010) if max <= min.
+**Errors:** [E8009](/language.ez/errors/E8009) if max is not positive, [E8010](/language.ez/errors/E8010) if max <= min.
 
 ### random_float
 

--- a/src/pages/docs/stdlib/std.md
+++ b/src/pages/docs/stdlib/std.md
@@ -113,7 +113,7 @@ temp rounded int = int(pi)  // 3
 
 **Returns:** `int` - The integer value.
 
-**Errors:** [E3005](/errors/E3005) if the string cannot be parsed as an integer.
+**Errors:** [E3005](/language.ez/errors/E3005) if the string cannot be parsed as an integer.
 
 ### float
 
@@ -131,7 +131,7 @@ temp decimal float = float(whole)  // 42.0
 
 **Returns:** `float` - The floating-point value.
 
-**Errors:** [E3006](/errors/E3006) if the string cannot be parsed as a float.
+**Errors:** [E3006](/language.ez/errors/E3006) if the string cannot be parsed as a float.
 
 ## Example Program
 

--- a/src/pages/docs/stdlib/strings.md
+++ b/src/pages/docs/stdlib/strings.md
@@ -83,7 +83,7 @@ strings.contains("hello world", "foo")    // false
 
 **Returns:** `bool` - true if found.
 
-**Errors:** [E10005](/errors/E10005) if arguments are not strings.
+**Errors:** [E10005](/language.ez/errors/E10005) if arguments are not strings.
 
 ### starts_with
 
@@ -98,7 +98,7 @@ strings.starts_with("hello world", "world")  // false
 
 **Returns:** `bool` - true if starts with prefix.
 
-**Errors:** [E10006](/errors/E10006) if arguments are not strings.
+**Errors:** [E10006](/language.ez/errors/E10006) if arguments are not strings.
 
 ### ends_with
 
@@ -113,7 +113,7 @@ strings.ends_with("hello world", "hello")  // false
 
 **Returns:** `bool` - true if ends with suffix.
 
-**Errors:** [E10007](/errors/E10007) if arguments are not strings.
+**Errors:** [E10007](/language.ez/errors/E10007) if arguments are not strings.
 
 ### index
 
@@ -128,7 +128,7 @@ strings.index("hello world", "foo")    // -1
 
 **Returns:** `int` - Index or -1.
 
-**Errors:** [E10004](/errors/E10004) if arguments are not strings.
+**Errors:** [E10004](/language.ez/errors/E10004) if arguments are not strings.
 
 ## Trimming
 
@@ -176,7 +176,7 @@ std.println(words)  // {"hello", "world"}
 
 **Returns:** `[string]` - Array of substrings.
 
-**Errors:** [E10001](/errors/E10001) if arguments are not strings.
+**Errors:** [E10001](/language.ez/errors/E10001) if arguments are not strings.
 
 ### join
 
@@ -192,7 +192,7 @@ std.println(strings.join(parts, ""))   // "abc"
 
 **Returns:** `string` - Joined string.
 
-**Errors:** [E10002](/errors/E10002) if the first argument is not an array.
+**Errors:** [E10002](/language.ez/errors/E10002) if the first argument is not an array.
 
 ## Replacing
 
@@ -209,7 +209,7 @@ strings.replace("aaa", "a", "b")  // "bbb"
 
 **Returns:** `string` - Modified string.
 
-**Errors:** [E10003](/errors/E10003) if arguments are not strings.
+**Errors:** [E10003](/language.ez/errors/E10003) if arguments are not strings.
 
 ### replace_first
 

--- a/src/pages/docs/stdlib/time.md
+++ b/src/pages/docs/stdlib/time.md
@@ -68,7 +68,7 @@ std.println("Done!")
 
 **Returns:** Nothing.
 
-**Errors:** [E11001](/errors/E11001) if the argument is not a number.
+**Errors:** [E11001](/language.ez/errors/E11001) if the argument is not a number.
 
 ### sleep_ms
 
@@ -84,7 +84,7 @@ std.println("Done!")
 
 **Returns:** Nothing.
 
-**Errors:** [E11002](/errors/E11002) if the argument is not an integer.
+**Errors:** [E11002](/language.ez/errors/E11002) if the argument is not an integer.
 
 ## Formatting
 
@@ -106,7 +106,7 @@ time.format(ts, "MMM DD, YYYY")       // "Dec 15, 2024"
 
 **Returns:** `string` - Formatted date string.
 
-**Errors:** [E11003](/errors/E11003) if format is not a string, [E11004](/errors/E11004) if timestamp is not an integer.
+**Errors:** [E11003](/language.ez/errors/E11003) if format is not a string, [E11004](/language.ez/errors/E11004) if timestamp is not an integer.
 
 ### Format Tokens
 
@@ -136,7 +136,7 @@ std.println(ts2)
 
 **Returns:** `int` - Unix timestamp.
 
-**Errors:** [E11005](/errors/E11005) if parsing fails, [E11006](/errors/E11006) if arguments are not strings.
+**Errors:** [E11005](/language.ez/errors/E11005) if parsing fails, [E11006](/language.ez/errors/E11006) if arguments are not strings.
 
 ## Creating Timestamps
 
@@ -156,7 +156,7 @@ temp ts2 int = time.make(2024, 12, 15, 14, 30, 0)
 
 **Returns:** `int` - Unix timestamp.
 
-**Errors:** [E11007](/errors/E11007) if arguments are not integers.
+**Errors:** [E11007](/language.ez/errors/E11007) if arguments are not integers.
 
 ## Date Arithmetic
 
@@ -177,7 +177,7 @@ temp much_later int = time.add_minutes(today, 90)
 
 **Returns:** `int` - New timestamp.
 
-**Errors:** [E11008](/errors/E11008) if timestamp is not an integer, [E11009](/errors/E11009) if amount is not an integer.
+**Errors:** [E11008](/language.ez/errors/E11008) if timestamp is not an integer, [E11009](/language.ez/errors/E11009) if amount is not an integer.
 
 ### diff
 
@@ -195,7 +195,7 @@ std.println("Days in 2024:", diff_days)
 
 **Returns:** `int` - Difference in seconds.
 
-**Errors:** [E11010](/errors/E11010) if arguments are not integers.
+**Errors:** [E11010](/language.ez/errors/E11010) if arguments are not integers.
 
 ## Date Components
 
@@ -248,7 +248,7 @@ std.println(time.is_leap_year(2023))  // false
 
 **Returns:** `bool` - true if leap year.
 
-**Errors:** [E11011](/errors/E11011) if the argument is not an integer.
+**Errors:** [E11011](/language.ez/errors/E11011) if the argument is not an integer.
 
 ### days_in_month
 
@@ -264,7 +264,7 @@ std.println(time.days_in_month(2024, 12)) // 31
 
 **Returns:** `int` - Number of days.
 
-**Errors:** [E11012](/errors/E11012) if arguments are not integers.
+**Errors:** [E11012](/language.ez/errors/E11012) if arguments are not integers.
 
 ## Performance Timing
 
@@ -288,7 +288,7 @@ std.println("Operation took " + string(elapsed) + "ms")
 
 **Returns:** `int` - Milliseconds elapsed.
 
-**Errors:** [E11013](/errors/E11013) if the argument is not an integer.
+**Errors:** [E11013](/language.ez/errors/E11013) if the argument is not an integer.
 
 ## Example Program
 


### PR DESCRIPTION
## Summary
- Fixed the "Install EZ" link in Quick Start section that led to a 404
- Added `/language.ez/` base URL prefix to all internal markdown links
- Fixed navigation links in docs, stdlib references, and error code links

## Test plan
- [x] Verified `yarn build` succeeds
- [x] Test links work on deployed site

Fixes #1