### PR TITLE
Update landing page What EZ Is / Is Not sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,19 +107,19 @@ const base = import.meta.env.BASE_URL;
             <div class="min-w-full px-4">
               <ul class="space-y-6 max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-black dark:text-white">
                 <li>
-                  <strong>A teaching language</strong> &mdash; designed to teach real programming fundamentals without unnecessary complexity.
+                  <strong>A teaching language that doesn't talk down to you</strong> &mdash; built for beginners to write working code in minutes, while learning the same fundamentals used in Go, Rust, and C.
                 </li>
                 <li>
-                  <strong>Statically typed</strong> &mdash; catch errors before your code runs, not after.
+                  <strong>Honest</strong> &mdash; no hidden magic, no implicit conversions, no guessing what the code does. When something happens, you know it's happening.
                 </li>
                 <li>
-                  <strong>Readable</strong> &mdash; plain English keywords like <code class="text-base px-2 py-1 bg-gray-100 dark:bg-gray-900 text-black dark:text-white">otherwise</code>, <code class="text-base px-2 py-1 bg-gray-100 dark:bg-gray-900 text-black dark:text-white">as_long_as</code>, and <code class="text-base px-2 py-1 bg-gray-100 dark:bg-gray-900 text-black dark:text-white">for_each</code>.
+                  <strong>Statically typed without the ceremony</strong> &mdash; types are checked before your code runs, but the syntax stays clean and readable.
                 </li>
                 <li>
-                  <strong>Batteries included</strong> &mdash; standard library for strings, arrays, math, time, and more.
+                  <strong>Procedural and functional</strong> &mdash; simple data + functions. Composition over abstraction.
                 </li>
                 <li>
-                  <strong>Honest</strong> &mdash; explicit behavior, no hidden magic, high quality error messages.
+                  <strong>Error messages that teach</strong> &mdash; Rust-inspired formatting that tells you what happened, where, why, and how to fix it.
                 </li>
               </ul>
             </div>
@@ -128,16 +128,19 @@ const base = import.meta.env.BASE_URL;
             <div class="min-w-full px-4">
               <ul class="space-y-6 max-w-2xl mx-auto text-lg sm:text-xl leading-relaxed text-black dark:text-white">
                 <li>
-                  <strong>Not a replacement for Python, Go, or Rust</strong> &mdash; EZ is for learning and scripting, not production systems.
+                  <strong>Not trying to be the next Python, Go, or Rust</strong> &mdash; EZ isn't competing with established languages. It has its own identity: a clean, honest language for learning real fundamentals and getting things done.
                 </li>
                 <li>
-                  <strong>Not object-oriented</strong> &mdash; no classes, ever. Composition over inheritance.
+                  <strong>Not object-oriented, ever</strong> &mdash; no classes, no inheritance, no interfaces, no methods. This is a permanent, philosophical stance.
                 </li>
                 <li>
-                  <strong>Not a toy</strong> &mdash; it's a real tool for writing real scripts and learning real fundamentals.
+                  <strong>Not a toy</strong> &mdash; simple doesn't mean limited. It's a real tool for writing real programs and learning real concepts.
                 </li>
                 <li>
-                  <strong>Not trying to be everything</strong> &mdash; intentionally limited scope, intentionally simple.
+                  <strong>Not magic-heavy or clever</strong> &mdash; EZ won't guess what you meant. It won't do things behind your back.
+                </li>
+                <li>
+                  <strong>Not trying to be everything</strong> &mdash; intentionally focused scope. Every feature has to justify its existence.
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
## Summary
- Rewrote "What EZ Is" and "What EZ Is Not" sections to sound more human
- Better reflects the language philosophy from context docs
- Removed limiting language about production use - EZ is a learning/general purpose language

## Changes
**What EZ Is:**
- A teaching language that doesn't talk down to you
- Honest (no hidden magic, no implicit conversions)
- Statically typed without the ceremony
- Procedural and functional
- Error messages that teach

**What EZ Is Not:**
- Not trying to be the next Python, Go, or Rust
- Not object-oriented, ever
- Not a toy
- Not magic-heavy or clever
- Not trying to be everything

## Test plan
- [x] `yarn build` passes