### PR TITLE
Update std.print() to std.printf() in docs

### DIFF
--- a/src/pages/docs/language/control-flow.md
+++ b/src/pages/docs/language/control-flow.md
@@ -82,22 +82,22 @@ The end value is **exclusive** (like Python and Go).
 ```ez
 // Single argument: range(end) - iterates 0 to end-1
 for i in range(5) {
-    std.print("${i} ")  // 0 1 2 3 4
+    std.printf("${i} ")  // 0 1 2 3 4
 }
 
 // Two arguments: range(start, end) - iterates start to end-1
 for i in range(2, 7) {
-    std.print("${i} ")  // 2 3 4 5 6
+    std.printf("${i} ")  // 2 3 4 5 6
 }
 
 // Three arguments: range(start, end, step)
 for i in range(0, 10, 2) {
-    std.print("${i} ")  // 0 2 4 6 8
+    std.printf("${i} ")  // 0 2 4 6 8
 }
 
 // Negative step for countdown
 for i in range(10, 0, -2) {
-    std.print("${i} ")  // 10 8 6 4 2
+    std.printf("${i} ")  // 10 8 6 4 2
 }
 ```
 
@@ -239,7 +239,7 @@ Loops can be nested for multi-dimensional iteration:
 // Multiplication table
 for i in range(1, 4) {
     for j in range(1, 4) {
-        std.print("${i * j} ")
+        std.printf("${i * j} ")
     }
     std.println("")
 }
@@ -254,7 +254,7 @@ for i in range(0, 3) {
         if j == 2 {
             break  // only breaks inner loop
         }
-        std.print("${i},${j} ")
+        std.printf("${i},${j} ")
     }
     std.println("")
 }
@@ -321,7 +321,7 @@ do main() {
         }
 
         if isPrime {
-            std.print("${num} ")
+            std.printf("${num} ")
         }
     }
     std.println("")

--- a/src/pages/docs/language/modules.md
+++ b/src/pages/docs/language/modules.md
@@ -62,7 +62,7 @@ do main() {
     using std
 
     println("No prefix needed!")
-    print("This works too")
+    printf("This works too")
 }
 ```
 
@@ -144,7 +144,7 @@ Core I/O and utilities:
 import @std
 
 std.println("Hello")      // Print with newline
-std.print("No newline")   // Print without newline
+std.printf("No newline")  // Print without newline
 std.typeof(value)         // Get type as string
 ```
 

--- a/src/pages/docs/stdlib/std.md
+++ b/src/pages/docs/stdlib/std.md
@@ -32,13 +32,13 @@ std.println("x =", x, "y =", y)
 
 **Returns:** Nothing.
 
-### `print()`
+### `printf()`
 `(values ...any) -> void`
 
 Prints one or more values to stdout without a trailing newline.
 
 ```ez
-std.print("Enter your name: ")
+std.printf("Enter your name: ")
 temp name string = input()
 std.println("Hello, " + name)
 ```


### PR DESCRIPTION
## Summary
Updates all documentation references from `std.print()` to `std.printf()` per SchoolyB/EZ#241.

## Files changed
- `src/pages/docs/stdlib/std.md` - renamed function docs
- `src/pages/docs/language/control-flow.md` - updated examples
- `src/pages/docs/language/modules.md` - updated examples

Closes #12