### PR TITLE
Make hero section fill viewport on mobile

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const base = import.meta.env.BASE_URL;
 
   <main class="flex-1">
     <!-- Hero Section -->
-    <section class="py-20 sm:py-32">
+    <section class="min-h-[calc(100dvh-4rem)] flex items-center justify-center py-12 sm:py-20">
       <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <h1 class="text-5xl sm:text-6xl font-bold tracking-tight mb-4 text-black dark:text-white">
           EZ Programming Language


### PR DESCRIPTION
## Summary
- Hero section now uses `min-h-[calc(100dvh-4rem)]` to fill the viewport minus header height
- Prevents the "What EZ is" section from peeking above the fold on mobile
- Content is vertically centered with flexbox

## Test plan
- [x] View homepage on mobile device
- [x] Verify hero fills the entire screen
- [x] Verify "What EZ is" section is not visible until scrolling